### PR TITLE
プラグイン側でkeyをかえてモデルをsaveしても、commentが１件しか作成されない(2回目以降がupdateになってしまう）件の対処

### DIFF
--- a/Model/Behavior/WorkflowCommentBehavior.php
+++ b/Model/Behavior/WorkflowCommentBehavior.php
@@ -81,6 +81,8 @@ class WorkflowCommentBehavior extends ModelBehavior {
 			'WorkflowComment' => 'Workflow.WorkflowComment',
 		]);
 
+		$model->WorkflowComment->create();
+
 		if (! Hash::get($model->data, 'WorkflowComment.comment')) {
 			return true;
 		}


### PR DESCRIPTION
本現象の対処として、WorkflowCommentビヘイビアのafterSave()に、$model->WorkflowComment->create()を追加しました。
